### PR TITLE
`nn_radius` improvements; setup with conda transparently

### DIFF
--- a/cyflann/__init__.py
+++ b/cyflann/__init__.py
@@ -25,9 +25,10 @@ from .flann_info import get_flann_info
 from .extensions import FLANNExtension
 
 # A test function, if we have nose.
-try:
-    from numpy.testing import nosetester
-    test = nosetester.NoseTester().test
-    del nosetester
-except ImportError:
-    pass
+# RAM: this is deprecated
+# try:
+#     from numpy.testing import nosetester
+#     test = nosetester.NoseTester().test
+#     del nosetester
+# except ImportError:
+#     pass

--- a/cyflann/flann_info.py
+++ b/cyflann/flann_info.py
@@ -1,7 +1,7 @@
 import errno
 from functools import partial
 import json
-import os
+import os, sys
 import subprocess
 
 
@@ -124,3 +124,7 @@ def get_flann_info(flann_dir=None, use_cache=True):
         _flann_info['libraries'].remove('flann_cpp')
 
     return _flann_info
+
+if __name__ == '__main__':
+    import pprint
+    pprint.pprint(get_flann_info())

--- a/cyflann/index.pyx
+++ b/cyflann/index.pyx
@@ -497,6 +497,12 @@ cdef class FLANNIndex:
 
         cdef float[:] the_query = self._check_array(query, dim=1)
 
+        # The maximum number of returned indices is limited not just by 
+        # the passed `max_nn` argument but also this `checks` global in 
+        # the parameters.
+        if self.params['checks'] < max_nn:
+            self.params['checks'] = max_nn
+
         cdef int npts = self._data.shape[0], dim = self._data.shape[1]
         cdef int qdim = the_query.shape[0]
         if qdim != dim:

--- a/cyflann/index.pyx
+++ b/cyflann/index.pyx
@@ -314,6 +314,9 @@ cdef class FLANNIndex:
         array = np.require(array,
                     requirements=['C_CONTIGUOUS', 'ALIGNED'],
                     dtype=np.float32)
+        if dim == 1 and array.ndim == 2 and array.size == 2:
+            # Let's us pass in [1,2] shape query points to nn_radius
+            array = array.squeeze()
         if dim == 2 and array.ndim == 1:
             array = array.reshape(1, array.size)
         if array.ndim != dim:

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,8 @@ except ImportError as e:
 
 # As seen in `appveyor.yml`, if `FLANN` is installed via conda we need to 
 # set the FLANN_DIR environment variable.
-if 'CONDA_PREFIX' in os.environ:
-    CONDA_PREFIX = os.environ['CONDA_PREFIX']
-    if not 'FLANN_DIR' in os.environ:
-        os.environ['FLANN_DIR'] = os.path.join(CONDA_PREFIX, 'Library')
+if 'CONDA_PREFIX' in os.environ and not 'FLANN_DIR' in os.environ:
+    os.environ['FLANN_DIR'] = os.path.join(os.environ['CONDA_PREFIX'], 'Library')
 
 try:
     from setuptools import setup, Command

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,12 @@ except ImportError as e:
     # Don't do this in the setup() requirements, because otherwise pip and
     # friends get too eager about updating numpy.
 
-# As seen in `appveyor.yml`, if `FLANN` is installed via conda we need to 
-# set the FLANN_DIR environment variable.
-if 'CONDA_PREFIX' in os.environ and not 'FLANN_DIR' in os.environ:
-    os.environ['FLANN_DIR'] = os.path.join(os.environ['CONDA_PREFIX'], 'Library')
+
+if os.name == 'nt':
+    # As seen in `appveyor.yml`, if `FLANN` is installed via conda we need to 
+    # set the FLANN_DIR environment variable.
+    if 'CONDA_PREFIX' in os.environ and not 'FLANN_DIR' in os.environ:
+        os.environ['FLANN_DIR'] = os.path.join(os.environ['CONDA_PREFIX'], 'Library')
 
 try:
     from setuptools import setup, Command

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,13 @@ except ImportError as e:
     # Don't do this in the setup() requirements, because otherwise pip and
     # friends get too eager about updating numpy.
 
+# As seen in `appveyor.yml`, if `FLANN` is installed via conda we need to 
+# set the FLANN_DIR environment variable.
+if 'CONDA_PREFIX' in os.environ:
+    CONDA_PREFIX = os.environ['CONDA_PREFIX']
+    if not 'FLANN_DIR' in os.environ:
+        os.environ['FLANN_DIR'] = os.path.join(CONDA_PREFIX, 'Library')
+
 try:
     from setuptools import setup, Command
     from setuptools.extension import Extension

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ if os.name == 'nt':
     # set the FLANN_DIR environment variable.
     if 'CONDA_PREFIX' in os.environ and not 'FLANN_DIR' in os.environ:
         os.environ['FLANN_DIR'] = os.path.join(os.environ['CONDA_PREFIX'], 'Library')
+elif os.name == 'posix':
+    # Must install flann via `sudo apt-get install libflann-dev`
+    os.environ['FLANN_DIR'] = '/usr'
 
 try:
     from setuptools import setup, Command


### PR DESCRIPTION
Hi,

Two suggested changes:

1. Some additional checks for `nn_radius` to allow [1,2]-shaped queries, which to me are the natural shape for such queries, and also ensures that `params['checks']` is high enough to accomodate `max_nn`.
2. In `setup.py`, try to infer if Conda is in use and set the appropriate environment variables in that case. Otherwise it doesn't work out-of-the-box.

I can squash or separate the PRs if you want, I was a bit lazy in committing.